### PR TITLE
Compiling using csproj small fix

### DIFF
--- a/src/Neo.Compiler.MSIL/Compiler.cs
+++ b/src/Neo.Compiler.MSIL/Compiler.cs
@@ -92,6 +92,7 @@ namespace Neo.Compiler
                 MetadataReference.CreateFromFile(Path.Combine(coreDir, "System.Runtime.Numerics.dll")),
                 MetadataReference.CreateFromFile(typeof(System.ComponentModel.DisplayNameAttribute).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Neo.SmartContract.Framework.SmartContract).Assembly.Location),
             });
             refs.AddRange(references.Select(u => MetadataReference.CreateFromFile(u)));
             return refs.ToArray();

--- a/src/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
+++ b/src/Neo.Compiler.MSIL/Neo.Compiler.MSIL.csproj
@@ -29,4 +29,7 @@
     <PackageReference Include="Neo" Version="3.0.0-CI00191" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Neo.SmartContract.Framework\Neo.SmartContract.Framework.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Neo.Compiler.MSIL/Program.cs
+++ b/src/Neo.Compiler.MSIL/Program.cs
@@ -40,7 +40,7 @@ namespace Neo.Compiler
 
             // Set current directory
             var fileInfo = new FileInfo(args.Filename);
-            if(!fileInfo.Exists)
+            if (!fileInfo.Exists)
             {
                 log.Log("Could not find file " + args.Filename);
                 Environment.Exit(-1);

--- a/src/Neo.Compiler.MSIL/Program.cs
+++ b/src/Neo.Compiler.MSIL/Program.cs
@@ -39,7 +39,15 @@ namespace Neo.Compiler
             log.Log("Neo.Compiler.MSIL console app v" + Assembly.GetEntryAssembly().GetName().Version);
 
             // Set current directory
-            var path = Path.GetDirectoryName(args.Filename);
+            var fileInfo = new FileInfo(args.Filename);
+            if(!fileInfo.Exists)
+            {
+                log.Log("Could not find file " + args.Filename);
+                Environment.Exit(-1);
+                return;
+            }
+
+            var path = fileInfo.Directory.FullName;
             if (!string.IsNullOrEmpty(path))
             {
                 try
@@ -101,7 +109,7 @@ namespace Neo.Compiler
                             .Select(u => u.Attribute("Update").Value)
                             .ToList();
 
-                        files.AddRange(Directory.GetFiles(Path.GetDirectoryName(args.Filename), "*.cs", SearchOption.AllDirectories));
+                        files.AddRange(Directory.GetFiles(path, "*.cs", SearchOption.AllDirectories));
                         files = files.Distinct().ToList();
 
                         log.Log("Compiling from csproj source");


### PR DESCRIPTION
Hi Shargon, this is my feedback, you don't have to accept it.
I added Neo Framework and loaded it when compiling, this way is much easier for people to use. Maybe we need to use nuget instead.